### PR TITLE
CI: fix code coverage step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: "3.10"
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       id: wheels_cache
       with:
         path: ./wheels
@@ -55,15 +55,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       id: conda_cache
       with:
         path: /tmp/test_env
         key: ${{ runner.os }}-test-env-py310-${{ hashFiles('tests/test-env-py310.yml') }}
 
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
       if: steps.conda_cache.outputs.cache-hit != 'true'
       with:
         channels: conda-forge,defaults
@@ -102,9 +102,9 @@ jobs:
       - build-test-env-base
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Get Conda Environment from Cache
-      uses: actions/cache@v3
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       id: conda_cache
       with:
         path: /tmp/test_env
@@ -127,9 +127,9 @@ jobs:
       - build-test-env-base
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Get Conda Environment from Cache
-      uses: actions/cache@v3
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       id: conda_cache
       with:
         path: /tmp/test_env
@@ -154,10 +154,10 @@ jobs:
       - run-black-check
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     - name: Get Conda Environment from Cache
-      uses: actions/cache@v3
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       id: conda_cache
       with:
         path: /tmp/test_env
@@ -191,7 +191,7 @@ jobs:
       if: |
         github.repository == 'opendatacube/odc-dscache'
 
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
       with:
         fail_ci_if_error: false
         verbose: false
@@ -206,17 +206,17 @@ jobs:
       - build-wheels
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     - name: Get Wheels from Cache
-      uses: actions/cache@v3
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       id: wheels_cache
       with:
         path: ./wheels
         key: wheels-${{ github.sha }}
 
     - name: Get Conda Environment from Cache
-      uses: actions/cache@v3
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       id: conda_cache
       with:
         path: /tmp/test_env

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,6 +153,9 @@ jobs:
       - build-test-env-base
       - run-black-check
 
+    permissions:
+      id-token: write
+
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -193,6 +196,7 @@ jobs:
 
       uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
       with:
+        use_oidc: true
         fail_ci_if_error: false
         verbose: false
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       id: wheels_cache
       with:
         path: ./wheels
         key: wheels-${{ github.sha }}
 
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: "3.10"
 

--- a/.github/workflows/publish-s3.yml
+++ b/.github/workflows/publish-s3.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       id: wheels_cache
       with:
         path: ./wheels


### PR DESCRIPTION
The code coverage currently
fails because this repository
does not pass any token, so
generate an OIDC token and use
that.

Also throw in a commit that pins
the CI actions by hash.