### PR TITLE
pyproject: use datacube < 1.10.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages = find_namespace:
 python_requires = >=3.10
 tests_require = pytest
 install_requires =
-    datacube>=1.9
+    datacube>=1.9,<1.10.0
     pandas
     psycopg2
     zstandard


### PR DESCRIPTION
This will keep the package working
even after the next API breaking
datacube version is released.