### PR TITLE
Update to black 26.1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,32 +95,6 @@ jobs:
       run: |
         mamba env export -p /tmp/test_env
 
-
-  run-black-check:
-    runs-on: ubuntu-latest
-    needs:
-      - build-test-env-base
-
-    steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - name: Get Conda Environment from Cache
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      id: conda_cache
-      with:
-        path: /tmp/test_env
-        key: ${{ runner.os }}-test-env-py310-${{ hashFiles('tests/test-env-py310.yml') }}
-
-    - name: Update PATH
-      shell: bash
-      run: |
-        echo "/tmp/test_env/bin" >> $GITHUB_PATH
-
-    - name: Check formatting (black)
-      shell: bash
-      run: |
-       black --check .
-
-
   run-mypy:
     runs-on: ubuntu-latest
     needs:
@@ -151,7 +125,6 @@ jobs:
 
     needs:
       - build-test-env-base
-      - run-black-check
 
     permissions:
       id-token: write
@@ -206,7 +179,6 @@ jobs:
 
     needs:
       - build-test-env-base
-      - run-black-check
       - build-wheels
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.37.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         args: ['-c', '.yamllint']
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
       - id: check-docstring-first
@@ -18,10 +18,10 @@ repos:
       - id: check-added-large-files
       - id: check-merge-conflict
   - repo: https://github.com/PyCQA/flake8
-    rev: '7.2.0'
+    rev: '7.3.0'
     hooks:
       - id: flake8
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.1.0
     hooks:
       - id: black

--- a/odc/dscache/tools/_index.py
+++ b/odc/dscache/tools/_index.py
@@ -302,7 +302,7 @@ and dataset_type_ref = (select id from agdc.dataset_type where name = %(product)
 
 def mid_longitude(geom: Geometry) -> float:
     """Return longitude of the middle point of the geomtry."""
-    ((lon,), _) = geom.centroid.to_crs("epsg:4326").xy
+    (lon,), _ = geom.centroid.to_crs("epsg:4326").xy
     return lon
 
 

--- a/odc/dscache/tools/profiling.py
+++ b/odc/dscache/tools/profiling.py
@@ -10,9 +10,7 @@ Total: {r.total:6.3f} sec
 TTFB : {r.ttfb:6.3f} sec
 .....: {r.uu:032X}
 ..
-""".format(
-        r=r, fps=r.count / r.total
-    ).strip()
+""".format(r=r, fps=r.count / r.total).strip()
 
 
 def ds_stream_test_func(dss, get_uuid=None):


### PR DESCRIPTION
Conda does not contain a black
package for 26.1.0, so remove
the CI job that runs formatting
checks.

The formatting check is still
done by pre-commit so this
is not a loss of functionality.